### PR TITLE
add /media to the ignored paths

### DIFF
--- a/src/common.bash
+++ b/src/common.bash
@@ -17,6 +17,7 @@ ignore_paths=(
     '/run'
     '/sys'
     '/tmp'
+    '/media'
     # '/var/.updated'
     '/var/cache'
     # '/var/lib'


### PR DESCRIPTION
Some people (like me) use /media to mount hard drives, more over this folder is never used to store configuration files so it can be safely ignored.