### PR TITLE
Use --dereference flag for cp

### DIFF
--- a/src/helpers.bash
+++ b/src/helpers.bash
@@ -80,7 +80,7 @@ function CopyFile() {
 
 	mkdir --parents "$(dirname "$output_dir"/files/"$file")"
 
-	cp --no-dereference \
+	cp --dereference \
 	   "$config_dir"/files/"$file" \
 	   "$output_dir"/files/"$file"
 


### PR DESCRIPTION
There's already a CreateLink, so there doesn't seem to be much point in copying symlinks. Using --dereference opens up more possibilities for storing config files.