### PR TITLE
Fix fatal error on non english systems

### DIFF
--- a/src/save.bash
+++ b/src/save.bash
@@ -28,7 +28,7 @@ function AconfSave() {
 		do
 			Log "%s...\r" "$(Color M "%q" "$package")"
 			local description
-			description="$(pacman --query --info "$package" | grep '^Description' | cut -d ':' -f 2)"
+			description="$(LC_ALL=C pacman --query --info "$package" | grep '^Description' | cut -d ':' -f 2)"
 			printf "AddPackage %q #%s\n" "$package" "$description" >> "$config_save_target"
 		done
 		modified=y
@@ -63,7 +63,7 @@ function AconfSave() {
 		do
 			Log "%s...\r" "$(Color M "%q" "$package")"
 			local description
-			description="$(pacman --query --info "$package" | grep '^Description' | cut -d ':' -f 2)"
+			description="$(LC_ALL=C pacman --query --info "$package" | grep '^Description' | cut -d ':' -f 2)"
 			printf "AddPackage --foreign %q #%s\n" "$package" "$description" >> "$config_save_target"
 		done
 		modified=y


### PR DESCRIPTION
Fixes fatal error caused by description extraction being hardcoded to english.
This commit introduces `expac` dependency.