### PR TITLE
Use $PACMAN instead of pacman

### DIFF
--- a/aconfmgr.1
+++ b/aconfmgr.1
@@ -85,6 +85,26 @@ Temporary directory, used for intermediary system state and configuration output
 
 The location is affected by the \fB$TMPDIR\fR environment variable.
 
+.SH "ENVIRONMENT VARIABLES"
+.TP
+.B $HOME
+Affects the default location of the configuration directory.
+
+.TP
+.B $PACMAN
+The command that will be used to check for missing dependencies and to install
+and remove packages. \fBpacman\fR's
+.IR -Qq ", " -Rns ", " -S ", " -T ", and " -U
+operations must be supported by this command. If the variable is not set or empty, \fBaconfmgr\fR will fall back to ‘pacman’.
+
+.TP
+.B $TMPDIR
+Affects the default location of the temporary directory.
+
+.TP
+.B $XDG_CONFIG_HOME
+Affects the default location of the configuration directory.
+
 .SH BUGS
 Please report defects and enhancement requests to the GitHub issue tracker:
 

--- a/src/apply.bash
+++ b/src/apply.bash
@@ -171,7 +171,7 @@ function AconfApply() {
 		function Details() { Log "Unpinning (setting install reason to 'as dependency') the following packages:%s\n" "$(Color M " %q" "${unknown_packages[@]}")" ; }
 		Confirm Details
 
-		Print0Array unknown_packages | sudo xargs -0 pacman --database --asdeps
+		Print0Array unknown_packages | sudo xargs -0 "$PACMAN" --database --asdeps
 
 		modified=y
 		LogLeave
@@ -184,7 +184,7 @@ function AconfApply() {
 
 	# Missing installed/unpinned packages (native and foreign packages that are implicitly installed,
 	# and listed in the configuration, but not marked as explicitly installed)
-	missing_unpinned_packages=($(comm -12 <(PrintArray missing_packages) <(pacman --query --quiet | sort)))
+	missing_unpinned_packages=($(comm -12 <(PrintArray missing_packages) <("$PACMAN" --query --quiet | sort)))
 
 	if [[ ${#missing_unpinned_packages[@]} != 0 ]]
 	then
@@ -193,7 +193,7 @@ function AconfApply() {
 		function Details() { Log "Pinning (setting install reason to 'explicitly installed') the following packages:%s\n" "$(Color M " %q" "${missing_unpinned_packages[@]}")" ; }
 		Confirm Details
 
-		Print0Array missing_unpinned_packages | sudo xargs -0 pacman --database --asexplicit
+		Print0Array missing_unpinned_packages | sudo xargs -0 "$PACMAN" --database --asexplicit
 
 		modified=y
 		LogLeave
@@ -201,7 +201,7 @@ function AconfApply() {
 
 
 	# Missing native packages (native packages that are listed in the configuration, but not installed)
-	missing_native_packages=($(comm -23 <(PrintArray packages) <(pacman --query --quiet | sort)))
+	missing_native_packages=($(comm -23 <(PrintArray packages) <("$PACMAN" --query --quiet | sort)))
 
 	if [[ ${#missing_native_packages[@]} != 0 ]]
 	then
@@ -217,7 +217,7 @@ function AconfApply() {
 	fi
 
 	# Missing foreign packages (foreign packages that are listed in the configuration, but not installed)
-	missing_foreign_packages=($(comm -23 <(PrintArray foreign_packages) <(pacman --query --quiet | sort)))
+	missing_foreign_packages=($(comm -23 <(PrintArray foreign_packages) <("$PACMAN" --query --quiet | sort)))
 
 	if [[ ${#missing_foreign_packages[@]} != 0 ]]
 	then
@@ -259,7 +259,7 @@ function AconfApply() {
 
 	# Orphan packages
 
-	if pacman --query --unrequired --unrequired --deps --quiet > /dev/null
+	if "$PACMAN" --query --unrequired --unrequired --deps --quiet > /dev/null
 	then
 		LogEnter "Pruning orphan packages...\n"
 
@@ -270,7 +270,7 @@ function AconfApply() {
 			LogEnter "Iteration %s:\n" "$(Color G "$iter")"
 
 			LogEnter "Querying orphan packages...\n"
-			orphan_packages=($(pacman --query --unrequired --unrequired --deps --quiet || true))
+			orphan_packages=($("$PACMAN" --query --unrequired --unrequired --deps --quiet || true))
 			LogLeave
 
 			if [[ ${#orphan_packages[@]} != 0 ]]
@@ -483,7 +483,7 @@ function AconfApply() {
 				absent=true
 			fi
 
-			package="$(pacman --query --owns --quiet "$file" | head -n 1 || true)"
+			package="$("$PACMAN" --query --owns --quiet "$file" | head -n 1 || true)"
 
 			if $absent
 			then
@@ -552,7 +552,7 @@ function AconfApply() {
 					LogEnter "%s the following file properties:\n" "$verb"
 					first=n
 				fi
-				
+
 				local kind="${key##*:}"
 				local file="${key%:*}"
 				local value="${output_file_props[$key]:-}"

--- a/src/save.bash
+++ b/src/save.bash
@@ -28,7 +28,7 @@ function AconfSave() {
 		do
 			Log "%s...\r" "$(Color M "%q" "$package")"
 			local description
-			description="$(LC_ALL=C pacman --query --info "$package" | grep '^Description' | cut -d ':' -f 2)"
+			description="$(LC_ALL=C "$PACMAN" --query --info "$package" | grep '^Description' | cut -d ':' -f 2)"
 			printf "AddPackage %q #%s\n" "$package" "$description" >> "$config_save_target"
 		done
 		modified=y
@@ -63,7 +63,7 @@ function AconfSave() {
 		do
 			Log "%s...\r" "$(Color M "%q" "$package")"
 			local description
-			description="$(LC_ALL=C pacman --query --info "$package" | grep '^Description' | cut -d ':' -f 2)"
+			description="$(LC_ALL=C "$PACMAN" --query --info "$package" | grep '^Description' | cut -d ':' -f 2)"
 			printf "AddPackage --foreign %q #%s\n" "$package" "$description" >> "$config_save_target"
 		done
 		modified=y


### PR DESCRIPTION
Following convention used in `makepkg`: if the `PACMAN` environment variable is set, use that as the path for the pacman executable instead of simply calling `pacman`. This is useful for users who prefer to do large installs (and the associated large downloads) using powerpill instead of native pacman, for example.