### PR TITLE
Make GetPackageOriginalFile idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ The list of provided helper functions:
 - `AddPackageGroup GROUP` - Adds all packages currently in the given group to the list of packages to be installed.
 - `CopyFile PATH [MODE [OWNER [GROUP]]]` - Copies a file from the `files` subdirectory to the output.
 - `CopyFileTo SRC-PATH DST-PATH [MODE [OWNER [GROUP]]]` - As above, but allows source and output paths to vary.
-- `CreateFile PATH [MODE [OWNER [GROUP]]]` - Creates an empty file, to be included in the output. Prints its absolute path to standard output.
-- `GetPackageOriginalFile PACKAGE PATH` - Extracts the original file from a package's archive for inclusion in the output. Prints its absolute path to standard output.
+- `CreateFile [--no-clobber] PATH [MODE [OWNER [GROUP]]]` - Creates an empty file, to be included in the output. Prints its absolute path to standard output.
+- `GetPackageOriginalFile [--no-clobber] PACKAGE PATH` - Extracts the original file from a package's archive for inclusion in the output. Prints its absolute path to standard output.
 - `CreateLink PATH TARGET [OWNER [GROUP]]` - Creates a symbolic link with the specified target.
 - `RemoveFile PATH` - Removes an earlier-added file.
 - `SetFileProperty PATH TYPE VALUE` - Sets a file property.

--- a/src/helpers.bash
+++ b/src/helpers.bash
@@ -177,9 +177,9 @@ function CreateFile() {
 		else
 			Log '%s: Overwriting %s, which was created earlier in the configuration. Use %s to keep old contents, or silence this warning by calling %s first.\n' \
 				"$(Color Y "Warning")" \
+				"$(Color C "%q" "$file")" \
 				"$(Color Y "CreateFile --no-clobber")" \
-				"$(Color Y "RemoveFile")" \
-				"$(Color C "%q" "$file")"
+				"$(Color Y "RemoveFile")"
 			config_warnings+=1
 		fi
 	fi
@@ -229,9 +229,9 @@ function GetPackageOriginalFile() {
 		else
 			Log '%s: Overwriting %s, which was created earlier in the configuration. Use %s to keep old contents, or silence this warning by calling %s first.\n' \
 				"$(Color Y "Warning")" \
+				"$(Color C "%q" "$file")" \
 				"$(Color Y "GetPackageOriginalFile --no-clobber")" \
-				"$(Color Y "RemoveFile")" \
-				"$(Color C "%q" "$file")"
+				"$(Color Y "RemoveFile")"
 			config_warnings+=1
 		fi
 	fi

--- a/src/helpers.bash
+++ b/src/helpers.bash
@@ -142,31 +142,54 @@ function CopyFileTo() {
 }
 
 #
-# CreateFile PATH [MODE [OWNER [GROUP]]]
+# CreateFile [--no-clobber] PATH [MODE [OWNER [GROUP]]]
 #
 # Creates an empty file, to be included in the output.
 # Prints its absolute path to standard output.
 #
 
 function CreateFile() {
+	keep=false
+	if [[ "$1" == "--no-clobber" ]]
+	then
+		keep=true
+		shift
+	fi
+
 	local file="$1"
 	local mode="${2:-}"
 	local owner="${3:-}"
 	local group="${4:-}"
 
-	mkdir --parents "$(dirname "$output_dir"/files/"$file")"
+	local output_file="$output_dir"/files/"$file"
 
-	truncate --size 0 "$output_dir"/files/"$file"
+	mkdir --parents "$(dirname "$output_file")"
+
+	if [[ -e "$output_file" ]]
+	then
+		if keep
+		then
+			printf '%s' "$output_file"
+			return
+		else
+			Log '%s: File path %s clobbered by CreateFile. Avoid via --no-clobber or silence warning via RemoveFile.\n' \
+				"$(Color Y "Warning")" \
+				"$(Color C "%q" "$file")"
+			config_warnings+=1
+		fi
+	fi
+
+	truncate --size 0 "$output_file"
 
 	SetFileProperty "$file" mode  "$mode"
 	SetFileProperty "$file" owner "$owner"
 	SetFileProperty "$file" group "$group"
 
-	printf '%s' "$output_dir"/files/"$file"
+	printf '%s' "$output_file"
 }
 
 #
-# GetPackageOriginalFile PACKAGE PATH
+# GetPackageOriginalFile [--no-clobber] PACKAGE PATH
 #
 # Extracts the original file from a package's archive for inclusion in the output.
 # Prints its absolute path to standard output.
@@ -175,12 +198,33 @@ function CreateFile() {
 #
 
 function GetPackageOriginalFile() {
+	keep=false
+	if [[ "$1" == "--no-clobber" ]]
+	then
+		keep=true
+		shift
+	fi
+
 	local package="$1" # Package to extract the file from
 	local file="$2" # Absolute path to file in package
 
 	local output_file="$output_dir"/files/"$file"
 
 	mkdir --parents "$(dirname "$output_file")"
+
+	if [[ -e "$output_file" ]]
+	then
+		if keep
+		then
+			printf '%s' "$output_file"
+			return
+		else
+			Log '%s: File path %s overwritten by GetPackageOriginalFile. Avoid via --no-clobber or silence warning via RemoveFile.\n' \
+				"$(Color Y "Warning")" \
+				"$(Color C "%q" "$file")"
+			config_warnings+=1
+		fi
+	fi
 
 	AconfGetPackageOriginalFile	"$package" "$file" > "$output_file"
 

--- a/src/helpers.bash
+++ b/src/helpers.bash
@@ -180,9 +180,13 @@ function GetPackageOriginalFile() {
 
 	local output_file="$output_dir"/files/"$file"
 
-	mkdir --parents "$(dirname "$output_file")"
+	if ! [[ -e "$output_file" ]]; then
 
-	AconfGetPackageOriginalFile	"$package" "$file" > "$output_file"
+		mkdir --parents "$(dirname "$output_file")"
+
+		AconfGetPackageOriginalFile	"$package" "$file" > "$output_file"
+
+	fi
 
 	printf '%s' "$output_file"
 }

--- a/src/helpers.bash
+++ b/src/helpers.bash
@@ -149,7 +149,7 @@ function CopyFileTo() {
 #
 
 function CreateFile() {
-	keep=false
+	local keep=false
 	if [[ "$1" == "--no-clobber" ]]
 	then
 		keep=true
@@ -165,15 +165,17 @@ function CreateFile() {
 
 	mkdir --parents "$(dirname "$output_file")"
 
-	if [[ -e "$output_file" ]]
+	if [[ -h "$output_file" || -e "$output_file" ]]
 	then
-		if keep
+		if $keep
 		then
 			printf '%s' "$output_file"
 			return
 		else
-			Log '%s: File path %s clobbered by CreateFile. Avoid via --no-clobber or silence warning via RemoveFile.\n' \
+			Log '%s: Overwriting %s, which was created earlier in the configuration. Use %s to keep old contents, or silence this warning by calling %s first.\n' \
 				"$(Color Y "Warning")" \
+				"$(Color Y "CreateFile --no-clobber")" \
+				"$(Color Y "RemoveFile")" \
 				"$(Color C "%q" "$file")"
 			config_warnings+=1
 		fi
@@ -212,15 +214,17 @@ function GetPackageOriginalFile() {
 
 	mkdir --parents "$(dirname "$output_file")"
 
-	if [[ -e "$output_file" ]]
+	if [[ -h "$output_file" || -e "$output_file" ]]
 	then
-		if keep
+		if $keep
 		then
 			printf '%s' "$output_file"
 			return
 		else
-			Log '%s: File path %s overwritten by GetPackageOriginalFile. Avoid via --no-clobber or silence warning via RemoveFile.\n' \
+			Log '%s: Overwriting %s, which was created earlier in the configuration. Use %s to keep old contents, or silence this warning by calling %s first.\n' \
 				"$(Color Y "Warning")" \
+				"$(Color Y "GetPackageOriginalFile --no-clobber")" \
+				"$(Color Y "RemoveFile")" \
 				"$(Color C "%q" "$file")"
 			config_warnings+=1
 		fi

--- a/src/helpers.bash
+++ b/src/helpers.bash
@@ -147,6 +147,9 @@ function CopyFileTo() {
 # Creates an empty file, to be included in the output.
 # Prints its absolute path to standard output.
 #
+# Avoids overwriting any pre-existing output file if
+# --no-clobber is provided.
+#
 
 function CreateFile() {
 	local keep=false
@@ -197,6 +200,9 @@ function CreateFile() {
 # Prints its absolute path to standard output.
 #
 # As in the case of CreateFile, the file can be further modified after extraction.
+#
+# Avoids overwriting any pre-existing output file if
+# --no-clobber is provided.
 #
 
 function GetPackageOriginalFile() {

--- a/src/helpers.bash
+++ b/src/helpers.bash
@@ -206,7 +206,7 @@ function CreateFile() {
 #
 
 function GetPackageOriginalFile() {
-	keep=false
+	local keep=false
 	if [[ "$1" == "--no-clobber" ]]
 	then
 		keep=true

--- a/src/helpers.bash
+++ b/src/helpers.bash
@@ -180,13 +180,9 @@ function GetPackageOriginalFile() {
 
 	local output_file="$output_dir"/files/"$file"
 
-	if ! [[ -e "$output_file" ]]; then
+	mkdir --parents "$(dirname "$output_file")"
 
-		mkdir --parents "$(dirname "$output_file")"
-
-		AconfGetPackageOriginalFile	"$package" "$file" > "$output_file"
-
-	fi
+	AconfGetPackageOriginalFile	"$package" "$file" > "$output_file"
 
 	printf '%s' "$output_file"
 }

--- a/src/save.bash
+++ b/src/save.bash
@@ -186,10 +186,15 @@ function AconfSave() {
 				else
 					local size
 					size=$(LC_ALL=C stat --format=%s "$system_file")
-					if [[ $size == 0 ]]
+					if [[ $size -eq 0 ]]
 					then
 						func=CreateFile
 						suffix=' > /dev/null'
+
+						if [[ -e "$output_file" ]] && [[ $(LC_ALL=C stat --format=%s "$output_file") -gt 0 ]]
+						then
+							printf 'RemoveFile %q\n' "$file" >> "$config_save_target"
+						fi
 					else
 						cp "$system_file" "$config_dir"/files/"$file"
 						func=CopyFile

--- a/src/save.bash
+++ b/src/save.bash
@@ -191,7 +191,7 @@ function AconfSave() {
 						func=CreateFile
 						suffix=' > /dev/null'
 
-						if [[ -h "$output_file" || -e "$output_file" ]] && [[ $(LC_ALL=C stat --format=%s "$output_file") -gt 0 ]]
+						if [[ -h "$output_file" || -e "$output_file" ]]
 						then
 							printf 'RemoveFile %q\n' "$file" >> "$config_save_target"
 						fi

--- a/src/save.bash
+++ b/src/save.bash
@@ -191,7 +191,7 @@ function AconfSave() {
 						func=CreateFile
 						suffix=' > /dev/null'
 
-						if [[ -e "$output_file" ]] && [[ $(LC_ALL=C stat --format=%s "$output_file") -gt 0 ]]
+						if [[ -h "$output_file" || -e "$output_file" ]] && [[ $(LC_ALL=C stat --format=%s "$output_file") -gt 0 ]]
 						then
 							printf 'RemoveFile %q\n' "$file" >> "$config_save_target"
 						fi

--- a/test/t/t-5_helpers-2_getpackageoriginalfile-1_reg.sh
+++ b/test/t/t-5_helpers-2_getpackageoriginalfile-1_reg.sh
@@ -4,16 +4,23 @@ source ./lib.bash
 # Test GetPackageOriginalFile helper.
 
 TestPhase_Setup ###############################################################
-TestAddFile /testfile.txt baz
-TestAddPackageFile test-package /testfile.txt foo
+TestAddFile /testfile1.txt baz
+TestAddPackageFile test-package /testfile1.txt foo
+TestAddFile /testfile2.txt baz
+TestAddPackageFile test-package /testfile2.txt foo
 TestCreatePackage test-package native
 
-TestAddConfig 'echo bar >> "$(GetPackageOriginalFile test-package /testfile.txt)"'
+TestAddConfig 'echo spam >> "$(GetPackageOriginalFile test-package /testfile1.txt)"'
+TestAddConfig 'echo bar >> "$(GetPackageOriginalFile test-package /testfile1.txt)"'
+
+TestAddConfig 'echo spam > "$(GetPackageOriginalFile --no-clobber test-package /testfile2.txt)"'
+TestAddConfig 'echo eggs >> "$(GetPackageOriginalFile --no-clobber test-package /testfile2.txt)"'
 
 TestPhase_Run #################################################################
 AconfApply
 
 TestPhase_Check ###############################################################
-diff -u "$test_fs_root"/testfile.txt /dev/stdin <<<foobar
+diff -u "$test_fs_root"/testfile1.txt /dev/stdin <<<foobar
+diff -u "$test_fs_root"/testfile2.txt /dev/stdin <<<spameggs
 
 TestDone ######################################################################

--- a/test/t/t-5_helpers-2_getpackageoriginalfile-1_reg.sh
+++ b/test/t/t-5_helpers-2_getpackageoriginalfile-1_reg.sh
@@ -21,6 +21,6 @@ AconfApply
 
 TestPhase_Check ###############################################################
 diff -u "$test_fs_root"/testfile1.txt /dev/stdin <<<foobar
-diff -u "$test_fs_root"/testfile2.txt /dev/stdin <<<spameggs
+diff -u "$test_fs_root"/testfile2.txt /dev/stdin <<<$'spam\neggs'
 
 TestDone ######################################################################


### PR DESCRIPTION
This way, if it is invoked multiple times on the same path (e.g. first some changes are made for one purpose, then some others are made for another unrelated purpose), the earlier changes are not lost.