### PR TITLE
Add support for colons in package descriptions

### DIFF
--- a/src/save.bash
+++ b/src/save.bash
@@ -30,7 +30,7 @@ function AconfSave() {
 		do
 			Log '%s...\r' "$(Color M "%q" "$package")"
 			local description
-			description="$(LC_ALL=C "$PACMAN" --query --info "$package" | grep '^Description' | cut -d ':' -f 2)"
+			description="$(LC_ALL=C "$PACMAN" --query --info "$package" | grep '^Description' | cut -d ':' -f 2-)"
 			printf 'AddPackage %q #%s\n' "$package" "$description" >> "$config_save_target"
 		done
 		modified=y
@@ -69,7 +69,7 @@ function AconfSave() {
 		do
 			Log '%s...\r' "$(Color M "%q" "$package")"
 			local description
-			description="$(LC_ALL=C "$PACMAN" --query --info "$package" | grep '^Description' | cut -d ':' -f 2)"
+			description="$(LC_ALL=C "$PACMAN" --query --info "$package" | grep '^Description' | cut -d ':' -f 2-)"
 			printf 'AddPackage --foreign %q #%s\n' "$package" "$description" >> "$config_save_target"
 		done
 		modified=y

--- a/test/t/lib-funcs-integ.bash
+++ b/test/t/lib-funcs-integ.bash
@@ -14,7 +14,7 @@ function TestInit() {
 	yay_opts+=(--noconfirm)
 	paru_opts+=(--noconfirm)
 
-	# pacaur insists that this is set, even if it will never inoke it
+	# pacaur insists that this is set, even if it will never invoke it
 	export EDITOR=/bin/cat
 
 	# Allows AUR helpers find perl tools etc.

--- a/test/t/lib-funcs-integ.bash
+++ b/test/t/lib-funcs-integ.bash
@@ -226,7 +226,7 @@ function TestCreatePackage() {
 pkgname=$package
 pkgver=$pkgver
 pkgrel=$pkgrel
-pkgdesc="Dummy aconfmgr test suite package"
+pkgdesc="Dummy aconfmgr test suite package: subtitle"
 arch=($arch)
 groups=($(PrintQArray groups))
 depends=($(PrintQArray depends))

--- a/test/t/mocks/pacman
+++ b/test/t/mocks/pacman
@@ -138,7 +138,7 @@ function pacman() {
 					for package in "${args[@]}"
 					do
 						printf 'Name            : %s\n' "$package"
-						printf 'Description     : %s\n' 'Dummy aconfmgr test suite package'
+						printf 'Description     : %s\n' 'Dummy aconfmgr test suite package: subtitle'
 						printf 'Version         : %s\n' '1.0'
 						printf 'Architecture    : %s\n' 'x86_64'
 						printf '\n'

--- a/test/t/t-1_save-1_packages-1_new.sh
+++ b/test/t/t-1_save-1_packages-1_new.sh
@@ -14,8 +14,8 @@ AconfSave
 
 TestPhase_Check ###############################################################
 TestExpectConfig <<EOF
-AddPackage test-native-explicit-package # Dummy aconfmgr test suite package
-AddPackage --foreign test-foreign-explicit-package # Dummy aconfmgr test suite package
+AddPackage test-native-explicit-package # Dummy aconfmgr test suite package: subtitle
+AddPackage --foreign test-foreign-explicit-package # Dummy aconfmgr test suite package: subtitle
 EOF
 
 TestDone ######################################################################


### PR DESCRIPTION
With the previous implementation, `aconfmgr save` would generate config
files with a truncated `AddPackage` comment if the package description
contains a colon character. For example:

    $ pacman -S potrace
    $ aconfmgr save
    $ cat 99-unsorted.sh
    AddPackage potrace # Utility for tracing a bitmap (input

This is because of the `cut` incantation we had:

    $ LC_ALL=C pacman --query --info "potrace" | grep '^Description' | cut -d ':' -f 2
     Utility for tracing a bitmap (input

But the description of potrace is actually longer than that:

    $ LC_ALL=C pacman --query --info "potrace" | grep '^Description'
    Description     : Utility for tracing a bitmap (input: PBM,PGM,PPM,BMP; output: EPS,PS,PDF,SVG,DXF,PGM,Gimppath,XFig)

Fortunately, `cut` has a pretty simple tweak to get everything from the
Nth field to the end of the line. From `man cut`:

    > N-     from N'th byte, character or field, to end of line

And this seems to work great!

    $ LC_ALL=C pacman --query --info "potrace" | grep '^Description' | cut -d ':' -f 2-
     Utility for tracing a bitmap (input: PBM,PGM,PPM,BMP; output: EPS,PS,PDF,SVG,DXF,PGM,Gimppath,XFig)