### PR TITLE
feat: add `aconfmgr cd` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Since the system configuration is described as shell scripts, it is trivially ex
 
 * [Usage](#usage)
   * [Installation](#installation)
+    * [Add cd command](#add-cd-command)
   * [First run](#first-run)
   * [Maintenance](#maintenance)
   * [Restoring](#restoring)
@@ -44,6 +45,21 @@ Since the system configuration is described as shell scripts, it is trivially ex
 ### Installation
 
 Simply clone (or [download](https://github.com/CyberShadow/aconfmgr/archive/master.zip)+unzip) the GitHub repository. `aconfmgr` will install dependencies as needed during execution. [An AUR package is also available](https://aur.archlinux.org/packages/aconfmgr-git/).
+
+#### Add cd command
+
+To be able to change to the aconfmgr configuration directory quickly with the command `aconfmgr cd`. Add the following function to your shell startup file. (e.g., `/etc/profile.d/aconfmgr.sh`, `~/.bashrc`, `~/.zshrc`).
+
+```sh
+function aconfmgr() {
+  if [ "$1" = "cd" ]; then
+    shift
+    cd ~/.config/aconfmgr
+  else
+    command aconfmgr "$@"
+  fi
+}
+```
 
 ### First run
 

--- a/src/main.bash
+++ b/src/main.bash
@@ -29,6 +29,7 @@ function Usage() {
 	printf '  apply   Update the system to reflect the current contents of the configuration\n'
 	printf '  check   Syntax-check and lint the configuration\n'
 	printf '  diff    Compare configuration and system\n'
+	printf '  cd      Change current directory to the configuration directory\n'
 	echo
 	printf 'Supported options:\n'
 	printf '  -h, --help               Print this message\n'
@@ -65,7 +66,7 @@ function Main() {
 	while [[ $# != 0 ]]
 	do
 		case "$1" in
-			save|apply|check|diff)
+			save|apply|check|diff|cd)
 				if [[ -n "$aconfmgr_action" ]]
 				then
 					UsageError "An action has already been specified"
@@ -78,6 +79,20 @@ function Main() {
 				then
 					aconfmgr_action_args=("$@")
 					break
+				elif [[ "$aconfmgr_action" == cd ]]
+				then
+					echo "To add the 'aconfmgr cd' function to your shell, add the following lines to your shell's startup file (e.g., ~/.bashrc, ~/.zshrc):"
+					echo ""
+					echo "function aconfmgr() {"
+					echo "  if [ \"\$1\" = \"cd\" ]; then"
+					echo "    shift"
+					echo "    cd ~/.config/aconfmgr"
+					echo "  else"
+					echo "    command aconfmgr \"\$@\""
+					echo "  fi"
+					echo "}"
+					echo ""
+					Exit 0
 				fi
 				;;
 			-h|--help|help)


### PR DESCRIPTION
Command to quickly change to the aconfmgr config directory, useful when managing the aconfmgr config with git where you need to enter the aconfmgr config directory to commit/push your changes.

Idea came from chezmoi which I use to manage my dotfiles.