### PR TITLE
Add helper function to ignore all packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ The list of provided helper functions:
 - `AddPackage [--foreign] PACKAGE...` - Adds a package to the list of packages to be installed.
 - `RemovePackage [--foreign] PACKAGE...` - Removes an earlier-added package to the list of packages to be installed.
 - `IgnorePackage [--foreign] PACKAGE...` - Adds a package to the list of [packages to be ignored](#ignoring-packages).
+- `IgnorePackagesAll` - Adds all installed packages to the list of [packages to be ignored](#ignoring-packages).
 - `AddPackageGroup GROUP` - Adds all packages currently in the given group to the list of packages to be installed.
 - `CopyFile PATH [MODE [OWNER [GROUP]]]` - Copies a file from the `files` subdirectory to the output.
 - `CopyFileTo SRC-PATH DST-PATH [MODE [OWNER [GROUP]]]` - As above, but allows source and output paths to vary.
@@ -173,6 +174,12 @@ IgnorePackage linux-git
 ```
 
 `aconfmgr save` will not update the configuration based on ignored packages' presence or absence, and `aconfmgr apply` will not install or uninstall them. The packages should also not be present in the configuration's package list, of course. To ignore a foreign package (e.g. a non-AUR foreign package), use the `--foreign` switch (e.g. `IgnorePackage --foreign my-flobulator`).
+
+To ignore all installed packages use the `IgnorePackagesAll` function:
+
+```bash
+IgnorePackagesAll
+```
 
 ### Inlining files
 

--- a/src/helpers.bash
+++ b/src/helpers.bash
@@ -74,6 +74,17 @@ function IgnorePackage() {
 }
 
 #
+# IgnorePackagesAll - does not accept arguments
+#
+# Ignores all installed packages. Usefule if you want to use another manger for managing packages.
+#
+
+function IgnorePackagesAll() {
+    mapfile -t ignore_foreign_packages < <(pacman -Qqm)
+    mapfile -t ignore_packages < <(pacman -Qqn)
+}
+
+#
 # CopyFile PATH [MODE [OWNER [GROUP]]]
 #
 # Copies a file from the "files" subdirectory to the output.


### PR DESCRIPTION
This adds a new helper function `IgnorePackagesAll` which allows to ignore all packages. It is useful in cases where aconfmgr is used only to decoratively change config files but packages are managed by another app (e.g. pacdef). 