### PR TITLE
Adapt check to handle migration from base-devel group to meta package

### DIFF
--- a/src/common.bash
+++ b/src/common.bash
@@ -990,14 +990,10 @@ function AconfMakePkg() {
 
 	if [[ $base_devel_installed == n ]]
 	then
-		LogEnter 'Making sure the %s group is installed...\n' "$(Color M base-devel)"
+		LogEnter 'Making sure the %s package is installed...\n' "$(Color M base-devel)"
 		ParanoidConfirm ''
-		local base_devel_all base_devel_missing
-		"$PACMAN" --sync --quiet --group base-devel | mapfile -t base_devel_all
-		( "$PACMAN" --deptest "${base_devel_all[@]}" || true ) | mapfile -t base_devel_missing
-		if [[ ${#base_devel_missing[@]} != 0 ]]
-		then
-			AconfInstallNative "${base_devel_missing[@]}"
+		if ! "$PACMAN" --query --quiet  base-devel > /dev/null 2>&1; then
+			AconfInstallNative base-devel
 		fi
 
 		LogLeave

--- a/src/common.bash
+++ b/src/common.bash
@@ -992,7 +992,8 @@ function AconfMakePkg() {
 	then
 		LogEnter 'Making sure the %s package is installed...\n' "$(Color M base-devel)"
 		ParanoidConfirm ''
-		if ! "$PACMAN" --query --quiet  base-devel > /dev/null 2>&1; then
+		if ! "$PACMAN" --query --quiet base-devel > /dev/null 2>&1
+		then
 			AconfInstallNative base-devel
 		fi
 


### PR DESCRIPTION
The base-devel group does not exist anymore and is now a meta-package (see https://archlinux.org/news/switch-to-the-base-devel-meta-package-requires-manual-intervention/)

The current check does not work anymore, so I replaced it with another one