### PR TITLE
test/GNUmakefile: Switch to SHA-256 for Arch bootstrap tarball

### DIFF
--- a/test/GNUmakefile
+++ b/test/GNUmakefile
@@ -160,7 +160,7 @@ $(COVERAGE_REPORT) : $(SRC) $(TESTSUITE) $(BASH_DEP) .simplecov
 ARCH_DATE=2022.04.05
 ARCH_TAR_FN=archlinux-bootstrap-$(ARCH_DATE)-x86_64.tar.gz
 ARCH_TAR_URL=https://archive.archlinux.org/iso/$(ARCH_DATE)/$(ARCH_TAR_FN)
-ARCH_TAR_SHA1=f06fe3d7a9427b62a07ec62a240b5c692e39eb6f
+ARCH_TAR_SHA256=4c5f4d0a77151781642ed1d450cd4b638581e5fe02be835759ae8e540fd0e08b
 ARCH_TAR_DIR=$(TMP)/arch
 ARCH_TAR=$(ARCH_TAR_DIR)/$(ARCH_TAR_FN)
 
@@ -169,7 +169,7 @@ $(ARCH_TAR_DIR) : | $(TMP)
 
 $(ARCH_TAR) : | $(ARCH_TAR_DIR)
 	curl --fail --output $@.tmp $(ARCH_TAR_URL)
-	printf "%s %s\n" $(ARCH_TAR_SHA1) $@.tmp | sha1sum -c
+	printf "%s %s\n" $(ARCH_TAR_SHA256) $@.tmp | sha256sum -c
 	mv $@.tmp $@
 
 DOCKER=docker


### PR DESCRIPTION
Newer tarballs use this hash function.

Unblocks automatically updating it using Renovate.