### PR TITLE
src: Separate ln options from arguments

### DIFF
--- a/src/common.bash
+++ b/src/common.bash
@@ -621,7 +621,7 @@ BEGIN {
 			mkdir --parents "$(dirname "$system_dir"/files/"$file")"
 			if [[ "$type" == "symbolic link" ]]
 			then
-				ln -s "$(sudo readlink "$file")" "$system_dir"/files/"$file"
+				ln -s -- "$(sudo readlink "$file")" "$system_dir"/files/"$file"
 			elif [[ "$type" == "regular file" || "$type" == "regular empty file" ]]
 			then
 				if [[ $size -gt $warn_size_threshold ]]

--- a/src/helpers.bash
+++ b/src/helpers.bash
@@ -247,7 +247,7 @@ function CreateLink() {
 
 	mkdir --parents "$(dirname "$output_dir"/files/"$file")"
 
-	ln --symbolic "$target" "$output_dir"/files/"$file"
+	ln --symbolic -- "$target" "$output_dir"/files/"$file"
 
 	SetFileProperty "$file" owner "$owner"
 	SetFileProperty "$file" group "$group"


### PR DESCRIPTION
In rare cases it might happen that a file is actually a broken symbolic link, to for example '-1'. Such a '-1' target is then interpreted as an option to ln instead of being properly treated as a file causing aconfmgr to fail during 'aconfmgr save'.

My real life example is:
```sh
$ sudo file /var/lib/jenkins/jobs/BSPQ19-E1/builds/lastSuccessfulBuild
/var/lib/jenkins/jobs/BSPQ19-E1/builds/lastSuccessfulBuild: broken symbolic link to -1
```