### PR TITLE
src/common.bash: Translate --yes into --noconfirm

### DIFF
--- a/src/common.bash
+++ b/src/common.bash
@@ -1254,13 +1254,7 @@ function AconfInstallNative() {
 	fi
 
 	local target_packages=("$@")
-	if [[ $prompt_mode == never ]]
-	then
-		# Some prompts default to 'no'
-		( yes || true ) | sudo "${pacman_opts[@]}" --confirm --sync "${asdeps_arr[@]}" "${target_packages[@]}"
-	else
-		sudo "${pacman_opts[@]}" --sync "${asdeps_arr[@]}" "${target_packages[@]}"
-	fi
+	sudo "${pacman_opts[@]}" --sync "${asdeps_arr[@]}" "${target_packages[@]}"
 }
 
 function AconfInstallForeign() {


### PR DESCRIPTION
TL;DR - I think I found a bug and fixed it. Please let me know if you think this is OK since I'm essentially removing one of your old commits and if a regression test is needed.

Currently the handling of the --yes option seems slightly unintuitive. Pacman's questions will only be responded to with "yes" but as a comment in the code nearby states sometimes a "no" is the default action to take.

There is also a subtle bug here, sometimes the default response is neither "yes" nor "no". For example when multiple packages fulfill the same dependency pacman will ask to select a package by typing in a number. Here aconfmgr fails to do the right thing. Instead of aborting on an invalid answer pacman will ask the question again and cause aconfmgr to be stuck in an endless loop.

The fix for this issue is to make pacman always use the default action by passing "--noconfirm" if aconfmgr was started with "--yes".

Regarding the already existing "--confirm" that was introduced in cd1c4b0f46: "common.bash: Automate pacman prompts more aggressively", the pacman man page states that "--confirm" only cancels a previous "--noconfirm" flag. Throw "--confirm" away.

The specific error that's fixed:
  $ aconfmgr --aur-helper yay --config ./ apply --yes
  (...)
  ::: Installing 375 missing native packages.
  resolving dependencies...
  :: There are 2 providers available for qt6-multimedia-backend:
  :: Repository extra
     1) qt6-multimedia-ffmpeg  2) qt6-multimedia-gstreamer

  Enter a number (default=1): error: invalid number: y

  Enter a number (default=1): error: invalid number: y
  (...)

This also fixes potential issues that might arise if "--yes" is used with non-english languages that will cause pacman to expect a word different than "yes" as confirmation.