### PR TITLE
src/apply.bash: Update pacman database before installing packages

### DIFF
--- a/src/apply.bash
+++ b/src/apply.bash
@@ -212,6 +212,16 @@ function AconfApply() {
 
 	LogLeave # Installing priority files
 
+	if LC_ALL=C "$PACMAN" 2>&1 | grep --extended-regexp --only-matching 'database file for [a-z]+ does not exist'
+	then
+		Log 'The pacman local package database is internally inconsistent. Perform a full refresh and system upgrade now?\n'
+		Confirm ''
+
+		LogEnter 'Performing a full refresh and system upgrade...\n'
+		sudo "$PACMAN" --sync --refresh --sysupgrade
+		LogLeave
+	fi
+
 	#
 	# Apply packages
 	#

--- a/test/t/mocks/pacman
+++ b/test/t/mocks/pacman
@@ -23,6 +23,10 @@ function pacman() {
 	local opt_groups=0
 	local opt_asdeps=false
 	local opt_asexplicit=false
+	local opt_refresh=false
+	local opt_upgrades=false
+	local opt_db_check=false
+	local opt_db_sync_check=false
 
 	local arg
 	for arg in "$@"
@@ -63,6 +67,20 @@ function pacman() {
 				;;
 			--asexplicit)
 				opt_asexplicit=true
+				;;
+			--refresh)
+				opt_refresh=true
+				;;
+			--upgrades)
+				opt_upgrades=true
+				;;
+			--check)
+				if $opt_db_check
+				then
+					opt_db_sync_check=true
+				else
+					opt_db_check=true
+				fi
 				;;
 			-*)
 				FatalError 'Unknown mocked pacman switch %s\n' "$(Color Y "$arg")"

--- a/test/t/t-2_apply-1_missing_pacman_db.sh
+++ b/test/t/t-2_apply-1_missing_pacman_db.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+source ./lib.bash
+
+TestIntegrationOnly
+
+# Test recovery from missing pacman databases.
+
+TestPhase_Setup ###############################################################
+command sudo rm -rf /var/lib/pacman/sync
+TestCreatePackage test-package native
+TestAddConfig AddPackage test-package
+
+TestPhase_Run #################################################################
+AconfApply
+
+TestPhase_Check ###############################################################
+TestExpectPacManLog <<EOF
+--sync test-package
+EOF
+
+TestDone ######################################################################


### PR DESCRIPTION
On a fresh install it might happen that after priority files including the pacman config are installed, the pacman database is not up to date.

  : Applying configuration...
  :: Installing priority files...
  ::: Installing /etc/pacman.conf...
  :::: Done.
  ::: Done.
  :: Configuring packages...
  ::: Unpinning 4 unknown packages.
  warning: database file for 'community' does not exist (use '-Sy' to download)
  warning: database file for 'multilib' does not exist (use '-Sy' to download)

This can later result in issues with finding the correct package during the "Apply packages" step.

  error: target not found: lib32-vulkan-intel
  error: target not found: lib32-vulkan-mesa-layers
  error: target not found: steam
  error: target not found: wine

To avoid this issue do as pacman suggests and update the database before "Apply packages"

Please let me know if I missed something. 