### PR TITLE
src/apply.bash: Fix optional sys upgrade

### DIFF
--- a/src/apply.bash
+++ b/src/apply.bash
@@ -212,13 +212,13 @@ function AconfApply() {
 
 	LogLeave # Installing priority files
 
-	if LC_ALL=C "$PACMAN" 2>&1 | grep --extended-regexp --only-matching 'database file for [a-z]+ does not exist'
+	if (LC_ALL=C "$PACMAN" 2>&1 || true) | grep --extended-regexp --only-matching 'database file for .+ does not exist'
 	then
 		Log 'The pacman local package database is internally inconsistent. Perform a full refresh and system upgrade now?\n'
 		Confirm ''
 
 		LogEnter 'Performing a full refresh and system upgrade...\n'
-		sudo "$PACMAN" --sync --refresh --sysupgrade
+		sudo "$PACMAN" --sync --refresh --sysupgrade --noconfirm
 		LogLeave
 	fi
 

--- a/test/t/t-2_apply-1_missing_pacman_db.sh
+++ b/test/t/t-2_apply-1_missing_pacman_db.sh
@@ -6,15 +6,16 @@ TestIntegrationOnly
 # Test recovery from missing pacman databases.
 
 TestPhase_Setup ###############################################################
-command sudo rm -rf /var/lib/pacman/sync
 TestCreatePackage test-package native
 TestAddConfig AddPackage test-package
+command sudo rm -rf /var/lib/pacman/sync
 
 TestPhase_Run #################################################################
 AconfApply
 
 TestPhase_Check ###############################################################
 TestExpectPacManLog <<EOF
+--sync --refresh --sysupgrade --noconfirm
 --sync test-package
 EOF
 


### PR DESCRIPTION
The previous implementation was insufficiently well tested. It didn't properly account for pipefail nor for pacman being inquisitive. Now it should actually work as expected.

I messed it up and I come back to make things better.